### PR TITLE
Fix broken link to procurement docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ We will know we are successful, if we can increase worker productivity and moral
 - [X] [Draft solicitation documents and vendor outreach](https://github.com/AlaskaDHSS/EIS-Modernization/wiki)
 - [X] First solicitation - RFP released November 3, 2017 (https://github.com/AlaskaDHSS/RFP-Search-Unification)
 - [X] Award first contract
-- [ ] Subsequent acquisition(s) - [In progress](https://github.com/AlaskaDHSS/EIS-Modernization/tree/mheadd-repo-cleanup/procurement-docs-far)
+- [ ] Subsequent acquisition(s) - [In progress](https://github.com/AlaskaDHSS/EIS-Modernization/tree/master/procurement-docs-far)
 
 ## Ongoing Strategic Concerns
 * Data normalization


### PR DESCRIPTION
The link previously pointed to seemingly deleted branch. I believe this fixes the link!