### PR TITLE
Update technical-prototyping.md

### DIFF
--- a/technical-prototyping.md
+++ b/technical-prototyping.md
@@ -1,7 +1,3 @@
-**Note:** The [information about the first technical prototype](technical-prototyping-unified-search.md) originally on this page has been moved.
-
----
-
 # Technical Prototyping
 Especially when working with legacy systems, **it's important to test technical assumptions *before* scoping any kind of procurement** because there are almost certainly unknown hazards that can put your procurement at risk. These hazards can't be known unless you start building something.
 
@@ -13,6 +9,7 @@ Unlike most kinds of prototypes, technical prototypes are not focused on user ex
 
 - [Unified search](technical-prototyping-unified-search.md)
 - [FFM automation](technical-prototyping-ffm-automated-registration.md)
+- [Automated Renewals](technical-prototyping-automated-renewal.md)
 
 ## When we prototype
 
@@ -39,13 +36,13 @@ Technical prototypes should address risks identified by the product team. The ap
 
 Through our initial prototypes efforts, we worked through a variety of initial challenges. Having done so, we are now positioned to more easily and quickly prove out technical questions. We can now take advantage of...
 
-- **Security plans** - Agreement with state security teams about the applicable security requirements (should connect to documentation of that agreement)
+- **Security plans** - Agreement with state security teams about the applicable security requirements 
 - **Tailored IT standards** - (Is this similar to the security plans above; should connect to documentation)
 - **[Agile and HCD practice](https://github.com/AlaskaDHSS/EIS-Modernization/blob/master/how-we-work.md)** - DHSS has embraced agile and human-centered design practices, works in product increments and sprints, and continuously seeks improvement.
-- **Test data** - Test data has been aligned across MCI, EIS, ARIES for UAT and dev environments. A process for adding new test data has been established (links to documentation)
-- **VSTS** - DHSS uses VSTS for version control, teams, git, security scans, etc. More information can be found [in the DevSecOps repo](https://github.com/AlaskaDHSS/DevSecOpsMvp/tree/master/vsts).
-- **GitHub** - While we work in VSTS, we sync our code with GitHub as part of our deployment cycle to ensure our open source software is visible and accessible.
-- **Service Proxy** - BizTalk ESB can be used to manage access to MCI, AREIS, EIS (Link to swagger docs)
+- **Test data** - Test data has been aligned across MCI, EIS, ARIES for UAT and dev environments. A process for adding new test data has been established 
+- **Azure DevOps** - DHSS uses Azure DevOps for version control, teams, git, security scans, etc. More information can be found [in the DevSecOps repo](https://github.com/AlaskaDHSS/DevSecOpsMvp/tree/master/vsts).
+- **GitHub** - While we work in Azure DevOps, we intend to sync our code with GitHub as part of our deployment cycle to ensure our open source software is visible and accessible.
+- **Service Proxy** - BizTalk ESB can be used to manage access to MCI, ARIES, EIS 
 - **Cloud/PaaS/Azure** - DHSS has adopted Azure and will be using this PaaS moving forward. More information on access can be found [in the DevSecOps repo](https://github.com/AlaskaDHSS/DevSecOpsMvp/blob/master/Azure.md).
 - **CI/CD pipeline** - Continuous Integration / Continuous Deployment mechanism are now in place and documented [in the DevSecOps repo](https://github.com/AlaskaDHSS/DevSecOpsMvp/blob/master/vsts/GitBranchingStrategy.md).
 
@@ -56,7 +53,7 @@ Producing technical prototypes requires DHSS developers and product managers to 
 - Familiarity with C# & .NET Core
 - Front-end development 
 - Experience with Azure
-- Familiarity with Git, VSTS and an understanding of CI/CD 
+- Familiarity with Git, Azure DevOps and an understanding of CI/CD 
 - Ability to identify risks
 - On-prem service/data expert
 - An experimental mindset - The team needs to be committed to trying things out, experimenting, and learning from both successes or failures


### PR DESCRIPTION
Updated as discussed. This readme has DevSecOpsMvp links: 2 at "Cloud/PaaS/Azure" and "CI/CD pipeline" under "Prototyping infrastructure"